### PR TITLE
Use nested containers within our tests to avoid mapping ports

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,8 +77,13 @@ node('docker') {
              * calls against it before calling it successful
              */
             stage('Verify Container') {
-                container.withRun("--link ${c.id}:nginx -e DATA_FILE_URL=http://nginx/plugins.json.gzip -p 8080:8080") { api ->
-                    sh 'wget --debug -O /dev/null --retry-connrefused --timeout 120 http://127.0.0.1:8080/versions'
+                container.withRun("--link ${c.id}:nginx -e DATA_FILE_URL=http://nginx/plugins.json.gzip") { api ->
+                    /* Re-using the `maven` image because it happens to have a
+                     * proper wget installed already inside of it
+                     */
+                    docker.image('maven').inside("--link ${api.id}:api") {
+                        sh 'wget --debug -O /dev/null --retry-connrefused --timeout 120 http://api:8080/versions'
+                    }
                 }
             }
 


### PR DESCRIPTION
This will avoid the machine running the Pipeline from needing to have port 8080
available for Docker to map

    docker: Error response from daemon: driver failed programming external
    connectivity on endpoint sick_liskov
    (852c2125c7e26d51062d9b8d96a3d8d22e3e54f1dcb5575ec5efa7dc4b8cce04): Bind for
    0.0.0.0:8080 failed: port is already allocated.