### PR TITLE
Explicitly set locale for DateTimeFormatters

### DIFF
--- a/src/main/java/io/jenkins/plugins/GeneratePluginData.java
+++ b/src/main/java/io/jenkins/plugins/GeneratePluginData.java
@@ -47,10 +47,10 @@ public class GeneratePluginData {
 
   private static final Logger logger = LoggerFactory.getLogger(GeneratePluginData.class);
 
-  private static final DateTimeFormatter BUILD_DATE_FORMATTER = DateTimeFormatter.ofPattern("MMM dd, yyyy");
+  private static final DateTimeFormatter BUILD_DATE_FORMATTER = DateTimeFormatter.ofPattern("MMM dd, yyyy", Locale.US);
 
   // java.time DateTimeFormatter.ISO_LOCAL_DATE_TIME uses nano-of-second where we're using milliseconds
-  private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SS'Z'");
+  private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SS'Z'", Locale.US);
 
   public static void main(String[] args) {
     final GeneratePluginData generatePluginData = new GeneratePluginData();


### PR DESCRIPTION
	Caused by: java.time.format.DateTimeParseException: Text 'Mar 29, 2016' could not be parsed at index 0
		at java.time.format.DateTimeFormatter.parseResolved0(DateTimeFormatter.java:1947)
		at java.time.format.DateTimeFormatter.parse(DateTimeFormatter.java:1849)
		at java.time.LocalDate.parse(LocalDate.java:400)
		at io.jenkins.plugins.GeneratePluginData.parsePlugin(GeneratePluginData.java:192)
		at io.jenkins.plugins.GeneratePluginData.generatePlugins(GeneratePluginData.java:120)