### PR TITLE
Only run the data generation twice an hour, similar to update site

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ properties([
     /* Only keep the most recent builds. */
     buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20')),
     /* build regularly */
-    pipelineTriggers([cron('H/10 * * * *')])
+    pipelineTriggers([cron('H/30 * * * *')])
 ])
 
 


### PR DESCRIPTION
This doesn't need to run so often. 30 minutes should be enough to pick up changes to the update center quickly enough.