### PR TITLE
[FIX WEBSITE-243] - Make API more robust

### DIFF
--- a/src/main/java/io/jenkins/plugins/GeneratePluginData.java
+++ b/src/main/java/io/jenkins/plugins/GeneratePluginData.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins;
 
 import io.jenkins.plugins.commons.JsonObjectMapper;
 import io.jenkins.plugins.models.*;
+import io.jenkins.plugins.utils.VersionUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.StatusLine;
@@ -260,7 +261,9 @@ public class GeneratePluginData {
   private void writePluginsToFile(List<Plugin> plugins) {
     final File data = Paths.get(System.getProperty("user.dir"), "target", "plugins.json.gzip").toFile();
     try(final Writer writer = new BufferedWriter(new OutputStreamWriter(new GZIPOutputStream(new FileOutputStream(data)), StandardCharsets.UTF_8))) {
-      JsonObjectMapper.getObjectMapper().writeValue(writer, new GeneratedPluginData(plugins));
+      final String mappingVersion = VersionUtils.getMappingVersion();
+      final String elasticsearchVersion = VersionUtils.getElasticsearchVersion();
+      JsonObjectMapper.getObjectMapper().writeValue(writer, new GeneratedPluginData(plugins, mappingVersion, elasticsearchVersion));
     } catch (Exception e) {
       logger.error("Problem writing plugin data to file", e);
       throw new RuntimeException(e);

--- a/src/main/java/io/jenkins/plugins/datastore/EmbeddedElasticsearchServer.java
+++ b/src/main/java/io/jenkins/plugins/datastore/EmbeddedElasticsearchServer.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.datastore;
 import io.jenkins.plugins.commons.JsonObjectMapper;
 import io.jenkins.plugins.models.GeneratedPluginData;
 import io.jenkins.plugins.services.ConfigurationService;
+import io.jenkins.plugins.utils.VersionUtils;
 import org.apache.commons.io.FileUtils;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.bulk.BulkItemResponse;
@@ -104,6 +105,18 @@ public class EmbeddedElasticsearchServer {
         logger.info("Plugin data is already up to date");
         return;
       }
+    }
+    final String mappingVersion = VersionUtils.getMappingVersion();
+    if (data.getMappingVersion() != null && !data.getMappingVersion().equalsIgnoreCase(mappingVersion)) {
+      logger.warn(String.format("Data has mapping version '%s' but application has '%s'", data.getMappingVersion(), mappingVersion));
+      logger.warn("Cannot index with new data. More than likely the application needs to be rebuilt and deployed first");
+      return;
+    }
+    final String elasticsearchVersion = VersionUtils.getElasticsearchVersion();
+    if (data.getElasticsearchVersion() != null && !data.getElasticsearchVersion().equalsIgnoreCase(elasticsearchVersion)) {
+      logger.warn(String.format("Data has Elasticsearch version '%s' but application has '%s'", data.getElasticsearchVersion(), elasticsearchVersion));
+      logger.warn("Cannot index with new data. More than likely the application needs to be rebuilt and deployed first");
+      return;
     }
     final ClassLoader cl = getClass().getClassLoader();
     final String index = String.format("%s%s", INDEX_PREFIX, TIMESTAMP_FORMATTER.format(data.getCreatedAt()));

--- a/src/main/java/io/jenkins/plugins/datastore/EmbeddedElasticsearchServer.java
+++ b/src/main/java/io/jenkins/plugins/datastore/EmbeddedElasticsearchServer.java
@@ -26,7 +26,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -87,37 +86,47 @@ public class EmbeddedElasticsearchServer {
   private void populateIndex() {
     try {
       final GeneratedPluginData data = configurationService.getIndexData();
-      doPopulateIndex(data);
+      if (shouldIndex(data)) {
+        doPopulateIndex(data);
+      }
     } catch (Exception e) {
       logger.error("Problem populating index", e);
       throw new RuntimeException("Problem populating index", e);
     }
   }
 
-  private void doPopulateIndex(GeneratedPluginData data) {
-    final Optional<LocalDateTime> optCreatedAt = getCurrentCreatedAt();
-    if (optCreatedAt.isPresent()) {
-      final LocalDateTime createdAt = optCreatedAt.get();
-      final LocalDateTime generatedCreatedAt = LocalDateTime.parse(TIMESTAMP_FORMATTER.format(data.getCreatedAt()), TIMESTAMP_FORMATTER);
-      logger.info("Current timestamp - " + createdAt);
-      logger.info("Data timestamp    - " + generatedCreatedAt);
-      if (createdAt.equals(generatedCreatedAt) || createdAt.isAfter(generatedCreatedAt)) {
-        logger.info("Plugin data is already up to date");
-        return;
+  private boolean shouldIndex(GeneratedPluginData data) {
+    if (data != null) {
+      final LocalDateTime createdAt = getCurrentCreatedAt();
+      if (createdAt != null) {
+        final LocalDateTime generatedCreatedAt = LocalDateTime.parse(TIMESTAMP_FORMATTER.format(data.getCreatedAt()), TIMESTAMP_FORMATTER);
+        logger.info("Current timestamp - " + createdAt);
+        logger.info("Data timestamp    - " + generatedCreatedAt);
+        if (createdAt.equals(generatedCreatedAt) || createdAt.isAfter(generatedCreatedAt)) {
+          logger.info("Plugin data is already up to date");
+          return false;
+        }
       }
+      final String mappingVersion = VersionUtils.getMappingVersion();
+      if (data.getMappingVersion() != null && !data.getMappingVersion().equalsIgnoreCase(mappingVersion)) {
+        logger.warn(String.format("Data has mapping version '%s' but application has '%s'", data.getMappingVersion(), mappingVersion));
+        logger.warn("Cannot index with new data. More than likely the application needs to be rebuilt and deployed first");
+        return false;
+      }
+      final String elasticsearchVersion = VersionUtils.getElasticsearchVersion();
+      if (data.getElasticsearchVersion() != null && !data.getElasticsearchVersion().equalsIgnoreCase(elasticsearchVersion)) {
+        logger.warn(String.format("Data has Elasticsearch version '%s' but application has '%s'", data.getElasticsearchVersion(), elasticsearchVersion));
+        logger.warn("Cannot index with new data. More than likely the application needs to be rebuilt and deployed first");
+        return false;
+      }
+      return true;
+    } else {
+      logger.info("Plugin data hasn't changed");
+      return false;
     }
-    final String mappingVersion = VersionUtils.getMappingVersion();
-    if (data.getMappingVersion() != null && !data.getMappingVersion().equalsIgnoreCase(mappingVersion)) {
-      logger.warn(String.format("Data has mapping version '%s' but application has '%s'", data.getMappingVersion(), mappingVersion));
-      logger.warn("Cannot index with new data. More than likely the application needs to be rebuilt and deployed first");
-      return;
-    }
-    final String elasticsearchVersion = VersionUtils.getElasticsearchVersion();
-    if (data.getElasticsearchVersion() != null && !data.getElasticsearchVersion().equalsIgnoreCase(elasticsearchVersion)) {
-      logger.warn(String.format("Data has Elasticsearch version '%s' but application has '%s'", data.getElasticsearchVersion(), elasticsearchVersion));
-      logger.warn("Cannot index with new data. More than likely the application needs to be rebuilt and deployed first");
-      return;
-    }
+  }
+
+  private void doPopulateIndex(GeneratedPluginData data) {
     final ClassLoader cl = getClass().getClassLoader();
     final String index = String.format("%s%s", INDEX_PREFIX, TIMESTAMP_FORMATTER.format(data.getCreatedAt()));
     try {
@@ -169,20 +178,20 @@ public class EmbeddedElasticsearchServer {
     }
   }
 
-  private Optional<LocalDateTime> getCurrentCreatedAt() {
+  private LocalDateTime getCurrentCreatedAt() {
     final Client client = getClient();
     if (client.admin().indices().prepareAliasesExist(ALIAS).get().exists()) {
       final String index = client.admin().indices().prepareGetAliases(ALIAS).get().getAliases().iterator().next().key;
       final String timestamp = index.substring(INDEX_PREFIX.length());
       try {
-        return Optional.of(LocalDateTime.parse(timestamp, TIMESTAMP_FORMATTER));
+        return LocalDateTime.parse(timestamp, TIMESTAMP_FORMATTER);
       } catch (Exception e) {
         logger.error("Problem parsing timestamp from index", e);
-        return Optional.empty();
+        return null;
       }
     } else {
       logger.info("Alias doesn't exist");
-      return Optional.empty();
+      return null;
     }
   }
 

--- a/src/main/java/io/jenkins/plugins/models/GeneratedPluginData.java
+++ b/src/main/java/io/jenkins/plugins/models/GeneratedPluginData.java
@@ -23,12 +23,20 @@ public class GeneratedPluginData {
   @JsonDeserialize(using = LocalDateTimeDeserializer.class)
   private LocalDateTime createdAt;
 
+  @JsonProperty("mappingVersion")
+  private String mappingVersion;
+
+  @JsonProperty("elasticsearchVersion")
+  private String elasticsearchVersion;
+
   public GeneratedPluginData() {
   }
 
-  public GeneratedPluginData(List<Plugin> plugins) {
+  public GeneratedPluginData(List<Plugin> plugins, String mappingVersion, String elasticsearchVersion) {
     this.plugins = plugins;
     this.createdAt = LocalDateTime.now();
+    this.mappingVersion = mappingVersion;
+    this.elasticsearchVersion = elasticsearchVersion;
   }
 
   public List<Plugin> getPlugins() {
@@ -47,4 +55,19 @@ public class GeneratedPluginData {
     this.createdAt = createdAt;
   }
 
+  public String getMappingVersion() {
+    return mappingVersion;
+  }
+
+  public void setMappingVersion(String mappingVersion) {
+    this.mappingVersion = mappingVersion;
+  }
+
+  public String getElasticsearchVersion() {
+    return elasticsearchVersion;
+  }
+
+  public void setElasticsearchVersion(String elasticsearchVersion) {
+    this.elasticsearchVersion = elasticsearchVersion;
+  }
 }

--- a/src/main/java/io/jenkins/plugins/services/ConfigurationService.java
+++ b/src/main/java/io/jenkins/plugins/services/ConfigurationService.java
@@ -10,7 +10,7 @@ public interface ConfigurationService {
   /**
    * <p>Get index data need to populating Elasticsearch</p>
    *
-   * @return GeneratedPluginData
+   * @return GeneratedPluginData, null if it hasn't changed since last time called
    * @throws ServiceException in case something goes wrong
      */
   GeneratedPluginData getIndexData() throws ServiceException;

--- a/src/main/java/io/jenkins/plugins/utils/VersionUtils.java
+++ b/src/main/java/io/jenkins/plugins/utils/VersionUtils.java
@@ -1,0 +1,22 @@
+package io.jenkins.plugins.utils;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.elasticsearch.Version;
+
+import java.io.IOException;
+
+public class VersionUtils {
+
+  public static String getMappingVersion() {
+    try {
+      return DigestUtils.sha256Hex(VersionUtils.class.getClassLoader().getResourceAsStream("elasticsearch/mappings/plugins.json"));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static String getElasticsearchVersion() {
+    return DigestUtils.sha256Hex(Version.CURRENT.toString());
+  }
+
+}


### PR DESCRIPTION
This adds two important features

- Adding mapping and ES version into the generated plugin data. These can be used to protect the server from ingesting a file it currently cannot use due to it needing to be rebuilt and deployed.
- Use ETag or Last-Modified to check if the generated plugin data has changed.

This will make the implementation of WEBSITE-279, and future changes to ES indexing, easier to deal with since we can know the server won't bomb.