### PR TITLE
[FIX WEBSITE-279] - Add GitHub information to scm

### DIFF
--- a/src/main/java/io/jenkins/plugins/GeneratePluginData.java
+++ b/src/main/java/io/jenkins/plugins/GeneratePluginData.java
@@ -135,7 +135,6 @@ public class GeneratePluginData {
     plugin.setName(json.getString("name"));
     plugin.setPreviousVersion(json.optString("previousVersion", null));
     plugin.setRequiredCore(json.optString("requiredCore"));
-    plugin.setScm(json.optString("scm", null));
     plugin.setSha1(json.optString("sha1", null));
     plugin.setTitle(json.optString("title", null));
     plugin.setUrl(json.optString("url", null));
@@ -203,6 +202,16 @@ public class GeneratePluginData {
     }
     final Stats stats = parseStatistics(plugin.getName(), json, statisticsPath);
     plugin.setStats(stats);
+    if (json.optString("scm", "").endsWith("github.com")) {
+      final String name = plugin.getName().endsWith("-plugin") ? plugin.getName() : plugin.getName() + "-plugin";
+      final String issues = "http://issues.jenkins-ci.org/secure/IssueNavigator.jspa?mode=hide&reset=true&jqlQuery=project+%3D+JENKINS+AND+status+in+%28Open%2C+%22In+Progress%22%2C+Reopened%29+AND+component+%3D+%27" + name + "%27";
+      final String link = "https://github.com/jenkinsci/" + name;
+      final String baseCompareUrl = String.format("%s/compare/%s-", link, plugin.getName());
+      final String inLatestRelease = String.format("%s%s...%s-%s", baseCompareUrl, plugin.getPreviousVersion(), plugin.getName(), plugin.getVersion());
+      final String sinceLatestRelease = String.format("%s%s...master", baseCompareUrl, plugin.getVersion());
+      final String pullRequests = link + "/pulls";
+      plugin.setScm(new Scm(issues, link, inLatestRelease, sinceLatestRelease, pullRequests));
+    }
     return plugin;
   }
 

--- a/src/main/java/io/jenkins/plugins/models/Plugin.java
+++ b/src/main/java/io/jenkins/plugins/models/Plugin.java
@@ -69,7 +69,7 @@ public class Plugin {
   private String requiredCore;
 
   @JsonProperty("scm")
-  private String scm;
+  private Scm scm;
 
   @JsonProperty("sha1")
   private String sha1;
@@ -94,7 +94,7 @@ public class Plugin {
 
   public Plugin(LocalDate buildDate, List<String> categories, List<Dependency> dependencies, List<Maintainer> maintainers,
                 String excerpt, String gav, List<String> labels, String name, LocalDateTime previousTimestamp,
-                String previousVersion, LocalDateTime releaseTimestamp, String requiredCore, String scm, String sha1,
+                String previousVersion, LocalDateTime releaseTimestamp, String requiredCore, Scm scm, String sha1,
                 Stats stats, String title, String url, String version, Wiki wiki) {
     this.buildDate = buildDate;
     this.categories = categories;
@@ -213,11 +213,11 @@ public class Plugin {
     this.requiredCore = requiredCore;
   }
 
-  public String getScm() {
+  public Scm getScm() {
     return scm;
   }
 
-  public void setScm(String scm) {
+  public void setScm(Scm scm) {
     this.scm = scm;
   }
 

--- a/src/main/java/io/jenkins/plugins/models/Scm.java
+++ b/src/main/java/io/jenkins/plugins/models/Scm.java
@@ -1,0 +1,74 @@
+package io.jenkins.plugins.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Scm {
+
+  @JsonProperty("issues")
+  private String issues;
+
+  @JsonProperty("link")
+  private String link;
+
+  @JsonProperty("inLatestRelease")
+  private String inLatestRelease;
+
+  @JsonProperty("sinceLatestRelease")
+  private String sinceLatestRelease;
+
+  @JsonProperty("pullRequests")
+  private String pullRequests;
+
+  public Scm() {
+  }
+
+  public Scm(String issues, String link, String inLatestRelease, String sinceLatestRelease, String pullRequests) {
+    this.issues = issues;
+    this.link = link;
+    this.inLatestRelease = inLatestRelease;
+    this.sinceLatestRelease = sinceLatestRelease;
+    this.pullRequests = pullRequests;
+  }
+
+  public String getIssues() {
+    return issues;
+  }
+
+  public void setIssues(String issues) {
+    this.issues = issues;
+  }
+
+  public String getLink() {
+    return link;
+  }
+
+  public void setLink(String link) {
+    this.link = link;
+  }
+
+  public String getInLatestRelease() {
+    return inLatestRelease;
+  }
+
+  public void setInLatestRelease(String inLatestRelease) {
+    this.inLatestRelease = inLatestRelease;
+  }
+
+  public String getSinceLatestRelease() {
+    return sinceLatestRelease;
+  }
+
+  public void setSinceLatestRelease(String sinceLatestRelease) {
+    this.sinceLatestRelease = sinceLatestRelease;
+  }
+
+  public String getPullRequests() {
+    return pullRequests;
+  }
+
+  public void setPullRequests(String pullRequests) {
+    this.pullRequests = pullRequests;
+  }
+}

--- a/src/main/resources/elasticsearch/mappings/plugins.json
+++ b/src/main/resources/elasticsearch/mappings/plugins.json
@@ -94,8 +94,29 @@
         "index" : "not_analyzed"
       },
       "scm" : {
-        "type" : "string",
-        "index" : "not_analyzed"
+        "type" : "nested",
+        "properties" : {
+          "issues" : {
+            "type" : "string",
+            "index" : "not_analyzed"
+          },
+          "link" : {
+            "type" : "string",
+            "index" : "not_analyzed"
+          },
+          "inLatestRelease": {
+            "type" : "string",
+            "index" : "not_analyzed"
+          },
+          "sinceLatestRelease": {
+            "type" : "string",
+            "index" : "not_analyzed"
+          },
+          "pullRequests": {
+            "type" : "string",
+            "index" : "not_analyzed"
+          }
+        }
       },
       "sha1" : {
         "type" : "string",


### PR DESCRIPTION
If the scm value from the update-center is for GitHub then index that
with the plugin so that the front end doesn't need to calculate it.

WEBSITE-243 needs to be merged first then deployed prior to merging this in order to protect the application from improper plugin data ingestion.