### PR TITLE
[WEBSITE-284] - Properly handle wiki failures

### DIFF
--- a/src/main/java/io/jenkins/plugins/endpoints/PluginEndpoint.java
+++ b/src/main/java/io/jenkins/plugins/endpoints/PluginEndpoint.java
@@ -4,6 +4,7 @@ import io.jenkins.plugins.models.Plugin;
 import io.jenkins.plugins.services.DatastoreService;
 import io.jenkins.plugins.services.ServiceException;
 import io.jenkins.plugins.services.WikiService;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,8 +42,7 @@ public class PluginEndpoint {
     try {
       final Plugin plugin = datastoreService.getPlugin(name);
       if (plugin != null) {
-        if (plugin.getWiki() != null &&
-          (plugin.getWiki().getUrl() != null && !plugin.getWiki().getUrl().isEmpty())) {
+        if (plugin.getWiki() != null && StringUtils.isNotBlank(plugin.getWiki().getUrl())) {
           final String content = wikiService.getWikiContent(plugin.getWiki().getUrl());
           plugin.getWiki().setContent(content);
         }

--- a/src/main/java/io/jenkins/plugins/services/impl/HttpClientWikiService.java
+++ b/src/main/java/io/jenkins/plugins/services/impl/HttpClientWikiService.java
@@ -20,7 +20,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
-import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -46,7 +45,7 @@ public class HttpClientWikiService implements WikiService {
         @Override
         public String load(String url) throws Exception {
           // Load the wiki content then clean it
-          final String rawContent = startGetWikiContent(url);
+          final String rawContent = doGetWikiContent(url);
           return cleanWikiContent(rawContent);
         }
       });
@@ -58,60 +57,30 @@ public class HttpClientWikiService implements WikiService {
       try {
         // This is what fires the CacheLoader that's defined in the postConstruct.
         return wikiContentCache.get(url);
-      } catch (ExecutionException e) {
+      } catch (Exception e) {
         logger.error("Problem getting wiki content", e);
-        throw new ServiceException("Problem getting wiki content", e);
+        return null;
       }
     } else {
       return null;
     }
   }
 
-  private String startGetWikiContent(String url) throws ServiceException {
-    final CloseableHttpClient httpClient = HttpClients.createDefault();
-    try {
-      return doGetWikiContent(httpClient, url, true);
+  private String doGetWikiContent(String url) {
+    final HttpGet get = new HttpGet(url);
+    try (final CloseableHttpClient httpClient = HttpClients.createDefault(); final CloseableHttpResponse response = httpClient.execute(get)) {
+      if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+        final HttpEntity entity = response.getEntity();
+        final String html = EntityUtils.toString(entity);
+        EntityUtils.consume(entity);
+        return html;
+      } else {
+        logger.warn("Unable to get content from {} - returned status code {}", url, response.getStatusLine().getStatusCode());
+        return null;
+      }
     } catch (Exception e) {
       logger.error("Problem getting wiki content", e);
-      throw new ServiceException("Problem getting wiki content", e);
-    } finally {
-      try {
-        httpClient.close();
-      } catch (IOException e) {
-        logger.warn("Problem closing HttpClient", e);
-      }
-    }
-  }
-
-  private String doGetWikiContent(CloseableHttpClient httpClient, String url, boolean follow) throws Exception {
-    final HttpGet get = new HttpGet(url);
-    final CloseableHttpResponse response = httpClient.execute(get);
-    try {
-      switch (response.getStatusLine().getStatusCode()) {
-        case HttpStatus.SC_MOVED_PERMANENTLY:
-        case HttpStatus.SC_MOVED_TEMPORARILY:
-        case HttpStatus.SC_SEE_OTHER:
-          if (follow) {
-            return doGetWikiContent(httpClient, response.getFirstHeader("Location").getValue(), false);
-          } else {
-            logger.warn("Already tried to follow to get wiki content.");
-            return null;
-          }
-        case HttpStatus.SC_OK:
-          final HttpEntity entity = response.getEntity();
-          final String html = EntityUtils.toString(entity);
-          EntityUtils.consume(entity);
-          return html;
-        default:
-          logger.warn("Unable to get content from " + url);
-          return null;
-      }
-    } finally {
-      try {
-        response.close();
-      } catch (IOException e) {
-        logger.warn("Problem closing response", e);
-      }
+      return null;
     }
   }
 

--- a/src/test/java/io/jenkins/plugins/services/WikiServiceTest.java
+++ b/src/test/java/io/jenkins/plugins/services/WikiServiceTest.java
@@ -32,6 +32,13 @@ public class WikiServiceTest {
   }
 
   @Test
+  public void testGetWikiContentNon200() {
+    final String url = "http://httpstat.us/500";
+    final String content = wikiService.getWikiContent(url);
+    Assert.assertNull(content);
+  }
+
+  @Test
   public void testCleanWikiContent() throws IOException {
     final File file = new File("src/test/resources/wiki_content.html");
     final String content = FileUtils.readFileToString(file, StandardCharsets.UTF_8);


### PR DESCRIPTION
The problem is the LoadingCache doesn't allow null values to be
associated with a key. In this case the url (key) cannot be mapped to
null content. The fix is ultimately returning null for the result of
getWikiContent in the catch.

Improvements include removing redundant code for following redirects.
HttpClients will automatically follow unless told not to.