### PR TITLE
[WEBSITE-342] Remove Plugin Information text coming macro

### DIFF
--- a/src/main/java/io/jenkins/plugins/services/impl/HttpClientWikiService.java
+++ b/src/main/java/io/jenkins/plugins/services/impl/HttpClientWikiService.java
@@ -104,6 +104,8 @@ public class HttpClientWikiService implements WikiService {
       return null;
     }
     final Element wikiContent = elements.first();
+    // Remove H4 tag with Plugin information, that is part of the jenkins-plugin-info macro
+    wikiContent.getElementsContainingOwnText("Plugin Information").tagName("h4").remove();
     // Remove any Confluence tables
     wikiContent.getElementsByClass("confluenceTable").remove();
     // Remove any table of contents


### PR DESCRIPTION
Removing the last piece of the macro, solid improvement :rocket: 

Current view on plugins.jenkins.io
![screenshot_2017-04-22_14-52-34](https://cloud.githubusercontent.com/assets/1661688/25304657/06ae0b6e-276c-11e7-9481-adeca94d3a3b.png)

After: (self-hosted site & api to confirm) :+1: 
![screenshot_2017-04-22_15-03-43](https://cloud.githubusercontent.com/assets/1661688/25304711/f3da565e-276c-11e7-820d-cf6f6ec20825.png)
