### PR TITLE
[FIX WEBSITE-363] - Fix thread crash

### DIFF
--- a/src/main/java/io/jenkins/plugins/services/impl/ElasticsearchPrepareDatastoreService.java
+++ b/src/main/java/io/jenkins/plugins/services/impl/ElasticsearchPrepareDatastoreService.java
@@ -54,7 +54,6 @@ public class ElasticsearchPrepareDatastoreService implements PrepareDatastoreSer
       }
     } catch (Exception e) {
       logger.error("Problem populating index", e);
-      throw new RuntimeException("Problem populating index", e);
     }
   }
 


### PR DESCRIPTION
When using `ScheduledExecutorService` any uncaught exceptions cause
subsequent runs of the thread to not run. Simply removing the throw
solves this issue.