### PR TITLE
Build update site metadata every 10 minutes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ properties([
     /* Only keep the most recent builds. */
     buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20')),
     /* build regularly */
-    pipelineTriggers([cron('H/30 * * * *')])
+    pipelineTriggers([cron('H/10 * * * *')])
 ])
 
 


### PR DESCRIPTION
The generation takes 1.5 minutes, so this shouldn't be too bad.

Companion to https://github.com/jenkins-infra/plugin-site-api/pull/50 (which would be set to 10 minutes in infra)