### PR TITLE
Plugins cannot depend on themselves

### DIFF
--- a/src/main/java/io/jenkins/plugins/generate/parsers/ImpliedDependenciesCoreResourceParser.java
+++ b/src/main/java/io/jenkins/plugins/generate/parsers/ImpliedDependenciesCoreResourceParser.java
@@ -59,7 +59,7 @@ public class ImpliedDependenciesCoreResourceParser implements PluginDataParser {
     List<Dependency> impliedDependencies = new ArrayList<>();
     VersionNumber requiredCore = new VersionNumber(plugin.getRequiredCore());
     for (Detachment d : detachments) {
-      if (requiredCore.isOlderThan(d.detachedCore)) {
+      if (requiredCore.isOlderThan(d.detachedCore) && !d.plugin.equals(plugin.getName())) {
         impliedDependencies.add(new Dependency(d.plugin, dependencyNameToTitleMap.get(d.plugin), false, d.impliedVersion.toString(), true));
       }
     }


### PR DESCRIPTION
This basically seems to be limited to jaxb plugin which was recently 'detached' but has a much older core dependency so that plugins can depend on it.

Untested.