### PR TITLE
Add missing module jaxb-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,11 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>2.2.11</version>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <version>3.1.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
     <dependency>
         <groupId>javax.xml.bind</groupId>
         <artifactId>jaxb-api</artifactId>
-        <version>2.2.11</version>
+        <version>2.3.1</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>


### PR DESCRIPTION
Since #54 and other PRs failed on missing dependencies, this PR checks if adding dependencies explicitly would make the CI build pass.

EDIT: probably caused by running on Java 11