### PR TITLE
[WEBSITE-639] - Missing slash in image URLs

### DIFF
--- a/src/main/java/io/jenkins/plugins/services/impl/GithubExtractor.java
+++ b/src/main/java/io/jenkins/plugins/services/impl/GithubExtractor.java
@@ -59,14 +59,14 @@ public class GithubExtractor implements WikiExtractor {
   }
 
   private void convertLinksToAbsolute(HttpClientWikiService service, Element wikiContent, String orgName, String repoName, String branch) {
-    String documentationHost = String.format("https://github.com/%s/%s/blob/%s/", orgName, repoName, branch);
-    String imageHost = String.format("https://raw.githubusercontent.com/%s/%s/%s/", orgName, repoName, branch);
+    String documentationHost = String.format("https://github.com/%s/%s/blob/%s", orgName, repoName, branch);
+    String imageHost = String.format("https://raw.githubusercontent.com/%s/%s/%s", orgName, repoName, branch);
 
     // Relative hyperlinks, we resolve "/docs/rest-api.adoc" as https://github.com/jenkinsci/folder-auth-plugin/blob/master/docs/rest-api.adoc
-    wikiContent.getElementsByAttribute("href").forEach(element -> service.replaceAttribute(element, "href", documentationHost, ""));
+    wikiContent.getElementsByAttribute("href").forEach(element -> service.replaceAttribute(element, "href", documentationHost, "/"));
     //TODO: Should we host images from our infrastructure? What are the GitHub terms here?
     // Relative image inclusions, we resolve /docs/images/screenshot.png as https://raw.githubusercontent.com/jenkinsci/folder-auth-plugin/master/docs/images/screenshot.png
-    wikiContent.getElementsByAttribute("src").forEach(element -> service.replaceAttribute(element, "src", imageHost, ""));
+    wikiContent.getElementsByAttribute("src").forEach(element -> service.replaceAttribute(element, "src", imageHost, "/"));
   }
 
   @Override

--- a/src/main/java/io/jenkins/plugins/services/impl/GithubExtractor.java
+++ b/src/main/java/io/jenkins/plugins/services/impl/GithubExtractor.java
@@ -59,8 +59,8 @@ public class GithubExtractor implements WikiExtractor {
   }
 
   private void convertLinksToAbsolute(HttpClientWikiService service, Element wikiContent, String orgName, String repoName, String branch) {
-    String documentationHost = String.format("https://github.com/%s/%s/blob/%s", orgName, repoName, branch);
-    String imageHost = String.format("https://raw.githubusercontent.com/%s/%s/%s", orgName, repoName, branch);
+    String documentationHost = String.format("https://github.com/%s/%s/blob/%s/", orgName, repoName, branch);
+    String imageHost = String.format("https://raw.githubusercontent.com/%s/%s/%s/", orgName, repoName, branch);
 
     // Relative hyperlinks, we resolve "/docs/rest-api.adoc" as https://github.com/jenkinsci/folder-auth-plugin/blob/master/docs/rest-api.adoc
     wikiContent.getElementsByAttribute("href").forEach(element -> service.replaceAttribute(element, "href", documentationHost, ""));


### PR DESCRIPTION
The image URLs seem still wrong after #54 
https://issues.jenkins-ci.org/browse/WEBSITE-406
@oleg-nenashev looped