### PR TITLE
[INFRA-2229] - Enable Release Drafter for the repository

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,6 @@
+# See https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
+_extends: jenkinsci/.github
+# Semantic versioning: https://semver.org/
+version-template: $MAJOR.$MINOR.$PATCH
+tag-template: v$NEXT_MINOR_VERSION
+name-template: v$NEXT_MINOR_VERSION


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/INFRA-2229

This patch needs the Release Drafter application to be enabled for the repository.

