### PR TITLE
[WEBSITE-650] Make sure Confluence API extractor uses UTF-8 to avoid broken symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ target/
 *.iml
 *.sw*
 plugins.json.gzip
+.classpath
+.project
+.settings

--- a/src/main/java/io/jenkins/plugins/services/impl/HttpClientWikiService.java
+++ b/src/main/java/io/jenkins/plugins/services/impl/HttpClientWikiService.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -108,7 +109,7 @@ public class HttpClientWikiService implements WikiService {
         final CloseableHttpResponse response = httpClient.execute(get)) {
       if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
         final HttpEntity entity = response.getEntity();
-        final String html = EntityUtils.toString(entity);
+        final String html = EntityUtils.toString(entity, StandardCharsets.UTF_8);
         EntityUtils.consume(entity);
         return html;
       } else {

--- a/src/test/java/io/jenkins/plugins/services/WikiServiceTest.java
+++ b/src/test/java/io/jenkins/plugins/services/WikiServiceTest.java
@@ -8,6 +8,7 @@ import io.jenkins.plugins.services.impl.WikiExtractor;
 
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matcher;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -183,9 +184,15 @@ public class WikiServiceTest {
 
   private void assertValidContent(String content) {
     Assert.assertNotNull("Wiki content is null", content);
+    Assert.assertThat(content, isValidUnicode());
     Assert.assertThat(content, CoreMatchers.not(CoreMatchers.containsString(
         HttpClientWikiService.EXTERNAL_DOCUMENTATION_PREFIX)));
     Assert.assertFalse("Wiki content is empty", content.isEmpty());
+  }
+
+  private Matcher<String> isValidUnicode() {
+    return CoreMatchers.not(CoreMatchers.containsString(
+        "\u00c2"));
   }
 
 }


### PR DESCRIPTION
See [WEBSITE-650](https://issues.jenkins-ci.org/browse/WEBSITE-650)

If the online service specifies encoding (confluence scrapper and GitHub API do), the HTTP library will use it. Fallback (for Confluence API) should however be set explicitly, because the global default is [wrong](https://android.googlesource.com/platform/external/apache-http/+/android-live-tv-l-mr1/src/org/apache/http/protocol/HTTP.java#86).