### PR TITLE
[WEBSITE-640] - Truncate heading and padding from README pages extracted from GitHub

### DIFF
--- a/src/main/java/io/jenkins/plugins/services/impl/GithubExtractor.java
+++ b/src/main/java/io/jenkins/plugins/services/impl/GithubExtractor.java
@@ -13,8 +13,14 @@ import org.apache.http.message.BasicHeader;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
 
 public class GithubExtractor implements WikiExtractor {
+  /**
+   * Bootstrap class setting !important padding. Scrapped by extractor
+   * to avoid !important override.
+   */
+  public static final String BOOTSTRAP_PADDING_5 = "p-5";
 
   private static final String README_ENDPOINT = "https://api.github.com/repos/jenkinsci/%s/readme?client_id=%s&client_secret=%s";
   private static final Pattern REPO_PATTERN = Pattern
@@ -61,7 +67,11 @@ public class GithubExtractor implements WikiExtractor {
   private void convertLinksToAbsolute(HttpClientWikiService service, Element wikiContent, String orgName, String repoName, String branch) {
     String documentationHost = String.format("https://github.com/%s/%s/blob/%s", orgName, repoName, branch);
     String imageHost = String.format("https://cdn.jsdelivr.net/gh/%s/%s@%s", orgName, repoName, branch);
-
+    Elements headings = wikiContent.getElementsByTag("H1");
+    if (headings.size() == 1) {
+      headings.get(0).remove();
+    }
+    wikiContent.getElementsByClass(BOOTSTRAP_PADDING_5).forEach(element -> element.removeClass(BOOTSTRAP_PADDING_5));
     // Relative hyperlinks, we resolve "/docs/rest-api.adoc" as https://github.com/jenkinsci/folder-auth-plugin/blob/master/docs/rest-api.adoc
     wikiContent.getElementsByAttribute("href").forEach(element -> service.replaceAttribute(element, "href", documentationHost, "/"));
     

--- a/src/test/java/io/jenkins/plugins/services/WikiServiceTest.java
+++ b/src/test/java/io/jenkins/plugins/services/WikiServiceTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 
 public class WikiServiceTest {
 
@@ -42,6 +43,12 @@ public class WikiServiceTest {
     final String url = "https://github.com/jenkinsci/labelled-steps-plugin";
     final String content = wikiService.getWikiContent(url);
     assertValidContent(content);
+    // heading inserted by plugin site, should be removed here
+    Assert.assertThat(content.toLowerCase(Locale.US),
+        CoreMatchers.not(CoreMatchers.containsString("<h1")));
+    // check removal of padding class that makes embedding hard
+    Assert.assertThat(content,
+        CoreMatchers.not(CoreMatchers.containsString(GithubExtractor.BOOTSTRAP_PADDING_5)));
   }
 
   @Test


### PR DESCRIPTION
See [WEBSITE-640](https://issues.jenkins-ci.org/browse/WEBSITE-640)

I think it's OK to fix these on extractor level as the API output should be optimized for embedding, also it's easier to avoid traversing the DOM it in two places.