### PR TITLE
Disable concurrent builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
     agent { label 'maven' }
 
     options {
+        disableConcurrentBuilds()
         buildDiscarder(logRotator(numToKeepStr: '7'))
         timestamps()
         timeout(time: 1, unit: 'HOURS')


### PR DESCRIPTION
It's not advisable to have concurrent builds for this periodically triggered job.
In case of resource shortage or long running builds, builds may pile up in the queue.