### PR TITLE
WIP - Fetch and process files directly from github without an api key

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,16 @@
       <version>2.2.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.asciidoctor</groupId>
+      <artifactId>asciidoctorj</artifactId>
+      <version>2.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.atlassian.commonmark</groupId>
+      <artifactId>commonmark</artifactId>
+      <version>0.14.0</version>
+   </dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/java/io/jenkins/plugins/services/impl/GithubContentsExtractor.java
+++ b/src/main/java/io/jenkins/plugins/services/impl/GithubContentsExtractor.java
@@ -1,7 +1,17 @@
 package io.jenkins.plugins.services.impl;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import static org.asciidoctor.Asciidoctor.Factory.create;
+
+import org.apache.http.Header;
+import org.asciidoctor.Asciidoctor;
+import org.commonmark.node.*;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
 
 public class GithubContentsExtractor extends GithubExtractor {
   private final static class GithubContentMatcher implements GithubMatcher {
@@ -13,18 +23,18 @@ public class GithubContentsExtractor extends GithubExtractor {
 
     @Override
     public String getEndpoint() {
-      return String.format(CONTENTS_ENDPOINT, matcher.group(3));
+      return matcher.group(3);
     }
 
     @Override
     public String getDirectory() {
-      String filePath = matcher.group(3);
-      return "/" + filePath.substring(0, filePath.lastIndexOf("/") + 1);
+      return "/";
     }
 
     @Override
     public String getBranch() {
-      return matcher.group(2);
+      String branch = matcher.group(2);
+      return branch == null ? "master" : branch;
     }
 
     @Override
@@ -38,10 +48,9 @@ public class GithubContentsExtractor extends GithubExtractor {
     }
   }
 
-  private static final Pattern REPO_PATTERN = Pattern
-      .compile("https?://github.com/jenkinsci/([^/.]+)/blob/([^/]+)/(.+\\.(md|adoc))$");
-  
-  private static final String CONTENTS_ENDPOINT = "contents/%s";
+  private static final Pattern REPO_PATTERN = Pattern.compile("https?://github.com/jenkinsci/([^/.]+)/blob/([^/]+)/(.+\\.(md|adoc))$");
+  private static final String API_URL_PATTERN = "https://raw.githubusercontent.com/jenkinsci/%s/%s/%s";
+  private static final Asciidoctor asciidoctor = create();
 
   @Override
   protected GithubMatcher getDelegate(String url) {
@@ -49,4 +58,37 @@ public class GithubContentsExtractor extends GithubExtractor {
     return new GithubContentMatcher(matcher);
   }
 
+  @Override
+  public String getApiUrl(String wikiUrl) {
+    GithubMatcher matcher = getDelegate(wikiUrl);
+
+    if (!matcher.find()) {
+      return null;
+    }
+
+    return String.format(API_URL_PATTERN, matcher.getRepo(), matcher.getBranch(), matcher.getEndpoint());
+  }
+
+  @Override
+  public String extractHtml(String apiContent, String url, HttpClientWikiService service) {
+    return super.extractHtml(this.getHTMLContent(apiContent, url), url, service);
+  }
+
+  public String getHTMLContent(String apiContent, String url) {
+    if (url.toLowerCase().endsWith(".adoc")) {
+      return asciidoctor.convert(apiContent,new HashMap<String, Object>());
+    }
+    if (url.toLowerCase().endsWith(".md")) {
+      Parser parser = Parser.builder().build();
+      Node document = parser.parse(apiContent);
+      HtmlRenderer renderer = HtmlRenderer.builder().build();
+      return renderer.render(document);
+    }
+    return apiContent;
+  }
+
+  @Override
+  public List<Header> getHeaders() {
+    return Collections.emptyList();
+  }
 }


### PR DESCRIPTION
Swaps out the hitting the github api endpoint, with the raw url, so no api calls

upside: 
No api limit

downside:
do adoc/markdown processing ourself.

I havn't compared output yet, but eyeballing it seems right