### PR TITLE
GitHub APP Auth

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -23,7 +23,6 @@ system, the following commands will run the tests properly:
 Inspect the `Makefile` for more targets, such as `all` which will run tests and
 build a working container.
 
-
 == Architecture
 
 The REST API calls are powered by Jersey 2.x running inside of Tomcat 8. Plugins
@@ -47,19 +46,36 @@ contains new data. If so the application will the reindex the Elasticsearch data
 == Run Local Plugin Site API
 
 ----
-GITHUB_CLIENT_ID="dummy"
+GITHUB_TOKEN=token from https://github.com/settings/tokens
 DATA_FILE_URL="https://ci.jenkins.io/job/Infra/job/plugin-site-api/job/generate-data/lastSuccessfulBuild/artifact/plugins.json.gzip" mvn jetty:run
 ----
 
 This will launch an embedded Jetty container accessible at `http://localhost:8080`.
 `DATA_FILE_URL` can point to `http`/`https` URLS or to local files using the `file://${path}` syntax.
-If `GITHUB_CLIENT_ID` is not valid GitHub Oauth App client ID, your site will be limited to fetching 60 plugin documentation pages per hour.
+
+If `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY` it will try to use a personal access token provided by `GITHUB_TOKEN` and failing that, your site will be limited to fetching 60 plugin documentation pages per hour.
+
+== Run in production mode
+
+You can still use the GITHUB_TOKEN method, but preference is to use github apps (https://github.com/settings/apps)
+Make sure your pem file is convered from the format github apps gives you to the PKCS#8 format by running
+
+----
+openssl pkcs8 -topk8 -inform PEM -outform PEM -in devpluginsjenkinsio.2020-07-28.private-key.pem -out githubapp.pem -nocrypt
+----
+
+Then configure it by
+
+----
+GITHUB_APP_ID=1234
+GITHUB_APP_PRIVATE_KEY="/path/to/pem/file"
+---
 
 == Run Docker Plugin Site API
 
 ----
 docker build -t jenkinsciinfra/plugin-site-api .
-docker run -p 8080:8080 -it -e DATA_FILE_URL="http://url.to/plugins.json.gzip" -e GITHUB_CLIENT_ID="dummy" jenkinsciinfra/plugin-site-api
+docker run -p 8080:8080 -it -e DATA_FILE_URL="http://url.to/plugins.json.gzip" jenkinsciinfra/plugin-site-api
 ----
 
 == Rebuild Elasticsearch data
@@ -716,10 +732,8 @@ Sample Response
 == Deployment to production
 
 This project is containerized via the `Dockerfile` that is located in the
-`deploy/` directory. The `Jenkinsfile` uses this `Dockerfile` in conjunction
-with the front-end code located in the
-link:https://github.com/jenkins-infra/plugin-site[jenkins-infra/plugin-site]
-repository to create a container fit for deployment.
+`deploy/` directory. The `Jenkinsfile` uses this `Dockerfile` create a container
+fit for deployment.
 
 Unfortunately, the build of this container must occur on a Jenkins cluster
 which is publicly inaccessible for security reasons. The private job polls SCM
@@ -732,8 +746,8 @@ Deploying:
 . Verify that a new container tag has been published
   link:https://hub.docker.com/r/jenkinsciinfra/plugin-site-api/tags/[here].
 . Submit a pull request to the
-  link:https://github.com/jenkins-infra/jenkins-infra[jenkins-infra/jenkins-infra]
-  repository updating the `profile::pluginsite::image_tag` value to the latest
+  link:https://github.com/jenkins-infra/jenkins-infra[jenkins-infra/charts]
+  repository updating the `backend.image.tag` value to the latest
   container's tag
-  (link:https://github.com/jenkins-infra/jenkins-infra/blob/bbfad9c04d5233d322a9e61aa9ab38890ab9991a/hieradata/common.yaml#L246[here])
+  (link:https://github.com/jenkins-infra/charts/blob/5e02db1ad84ac0634d256da155717b7664be1849/charts/plugin-site/values.yaml#L10[here])
 . Once that is merged the changes will be live

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,11 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-smile</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>19.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -7,10 +7,11 @@
   <version>1.11.2-SNAPSHOT</version>
 
   <properties>
-    <jackson.version>2.6.6</jackson.version>
+    <jackson.version>2.9.0</jackson.version>
     <jersey.version>2.23.1</jersey.version>
     <slf4j.version>1.7.21</slf4j.version>
     <sentry.version>1.7.30</sentry.version>
+    <jjwt.version>0.10.5</jjwt.version>
     <maven.deploy.skip>true</maven.deploy.skip>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
@@ -163,6 +164,28 @@
       <groupId>io.sentry</groupId>
       <artifactId>sentry-logback</artifactId>
       <version>${sentry.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.kohsuke</groupId>
+      <artifactId>github-api</artifactId>
+      <version>1.101</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-api</artifactId>
+      <version>${jjwt.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+      <version>${jjwt.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+      <version>${jjwt.version}</version>
+      <scope>runtime</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/io/jenkins/plugins/commons/JwtHelper.java
+++ b/src/main/java/io/jenkins/plugins/commons/JwtHelper.java
@@ -14,6 +14,7 @@ import java.util.Date;
 import static java.util.Objects.requireNonNull;
 import java.util.concurrent.TimeUnit;
 
+// taken almost in its entirety from https://github.com/jenkinsci/github-branch-source-plugin/blob/07b69ab4f9d9ed718416ac63af67102de5e172fa/src/main/java/org/jenkinsci/plugins/github_branch_source/JwtHelper.java
 public class JwtHelper {
   public static class InvalidPrivateKeyException extends RuntimeException {
 

--- a/src/main/java/io/jenkins/plugins/commons/JwtHelper.java
+++ b/src/main/java/io/jenkins/plugins/commons/JwtHelper.java
@@ -1,0 +1,92 @@
+package io.jenkins.plugins.commons;
+
+import io.jsonwebtoken.JwtBuilder;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.security.GeneralSecurityException;
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import java.util.Date;
+
+import static java.util.Objects.requireNonNull;
+import java.util.concurrent.TimeUnit;
+
+public class JwtHelper {
+  public static class InvalidPrivateKeyException extends RuntimeException {
+
+    public InvalidPrivateKeyException(String message) {
+      super(message);
+    }
+  }
+
+  /**
+   * Somewhat less than the <a href="https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app">maximum JWT validity</a>.
+   */
+  public static final long VALIDITY_MS = TimeUnit.MINUTES.toMillis(8);
+
+  /**
+   * Create a JWT for authenticating to GitHub as an app installation
+   * @param githubAppId the app ID
+   * @param privateKey PKC#8 formatted private key
+   * @return JWT for authenticating to GitHub
+   */
+  public static String createJWT(String githubAppId, final String privateKey) {
+    requireNonNull(githubAppId, privateKey);
+
+    SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.RS256;
+
+    long nowMillis = System.currentTimeMillis();
+    Date now = new Date(nowMillis);
+
+    Key signingKey;
+    try {
+      signingKey = getPrivateKeyFromString(privateKey);
+    } catch (GeneralSecurityException e) {
+      throw new IllegalArgumentException("Couldn't parse private key for GitHub app, make sure it's PKCS#8 format", e);
+    }
+
+    JwtBuilder builder = Jwts.builder()
+      .setIssuedAt(now)
+      .setIssuer(githubAppId)
+      .signWith(signingKey, signatureAlgorithm);
+
+    Date exp = new Date(nowMillis + VALIDITY_MS);
+    builder.setExpiration(exp);
+
+    return builder.compact();
+  }
+
+  /**
+   * Convert a PKCS#8 formatted private key in string format into a java PrivateKey
+   * @param key PCKS#8 string
+   * @return private key
+   * @throws GeneralSecurityException if we couldn't parse the string
+   */
+  public static PrivateKey getPrivateKeyFromString(final String key) throws GeneralSecurityException {
+    if (key.contains("RSA")) {
+      throw new InvalidPrivateKeyException(
+        "Private key must be a PKCS#8 formatted string, to convert it from PKCS#1 use: "
+          + "openssl pkcs8 -topk8 -inform PEM -outform PEM -in current-key.pem -out new-key.pem -nocrypt"
+      );
+    }
+
+    String privateKeyContent = key.replaceAll("\\n", "")
+      .replace("-----BEGIN PRIVATE KEY-----", "")
+      .replace("-----END PRIVATE KEY-----", "");
+
+    KeyFactory kf = KeyFactory.getInstance("RSA");
+
+    try {
+      byte[] decode = Base64.getDecoder().decode(privateKeyContent);
+      PKCS8EncodedKeySpec keySpecPKCS8 = new PKCS8EncodedKeySpec(decode);
+
+      return kf.generatePrivate(keySpecPKCS8);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidPrivateKeyException("Failed to decode private key: " + e.getMessage());
+    }
+  }
+
+}

--- a/src/main/java/io/jenkins/plugins/services/ConfigurationService.java
+++ b/src/main/java/io/jenkins/plugins/services/ConfigurationService.java
@@ -1,7 +1,9 @@
 package io.jenkins.plugins.services;
 
 import io.jenkins.plugins.models.GeneratedPluginData;
-import org.apache.http.client.CredentialsProvider;
+import org.apache.http.Header;
+
+import java.util.List;
 
 /**
  * <p>Get various configuration pieces for the application</p>
@@ -16,15 +18,11 @@ public interface ConfigurationService {
      */
   GeneratedPluginData getIndexData() throws ServiceException;
 
-  CredentialsProvider getJiraCredentials();
+  List<Header> getJiraCredentials();
 
-  CredentialsProvider getGithubCredentials();
+  List<Header> getGithubCredentials();
 
   String getJiraURL();
-
-  String getGithubClientId();
-
-  String getGithubClientSecret();
 
   String getGithubApiBase();
 }

--- a/src/main/java/io/jenkins/plugins/services/impl/DefaultConfigurationService.java
+++ b/src/main/java/io/jenkins/plugins/services/impl/DefaultConfigurationService.java
@@ -139,6 +139,7 @@ public class DefaultConfigurationService implements ConfigurationService {
     return Collections.singletonList(new BasicHeader(HttpHeaders.AUTHORIZATION, "Basic " + encoding));
   }
 
+  // borrowed from https://github.com/jenkinsci/github-branch-source-plugin/blob/07b69ab4f9d9ed718416ac63af67102de5e172fa/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java#L107
   @SuppressWarnings("deprecation") // preview features are required for GitHub app integration, GitHub api adds deprecated to all preview methods
   String generateAppInstallationToken(String appId, String appPrivateKey) {
     try {

--- a/src/main/java/io/jenkins/plugins/services/impl/HttpClient.java
+++ b/src/main/java/io/jenkins/plugins/services/impl/HttpClient.java
@@ -32,12 +32,6 @@ public class HttpClient {
       .setSocketTimeout(5000)
       .build();
     HttpClientBuilder httpClientBuilder = HttpClients.custom();
-    if (url.startsWith(this.configurationService.getGithubApiBase())) {
-      httpClientBuilder.setDefaultCredentialsProvider(this.configurationService.getGithubCredentials());
-    } else if (url.startsWith(this.configurationService.getJiraURL())) {
-      httpClientBuilder.setDefaultCredentialsProvider(this.configurationService.getJiraCredentials());
-    }
-
     return httpClientBuilder.setDefaultRequestConfig(requestConfig).build();
   }
 

--- a/src/main/java/io/jenkins/plugins/services/impl/HttpClient.java
+++ b/src/main/java/io/jenkins/plugins/services/impl/HttpClient.java
@@ -22,8 +22,12 @@ import java.util.List;
 public class HttpClient {
   protected Logger logger = LoggerFactory.getLogger(HttpClient.class);
 
+  protected final ConfigurationService configurationService;
+
   @Inject
-  protected ConfigurationService configurationService;
+  protected HttpClient(ConfigurationService configurationService) {
+    this.configurationService = configurationService;
+  }
 
   protected CloseableHttpClient getHttpClient(String url) {
     final RequestConfig requestConfig = RequestConfig.copy(RequestConfig.DEFAULT)
@@ -33,9 +37,6 @@ public class HttpClient {
       .build();
     HttpClientBuilder httpClientBuilder = HttpClients.custom();
     return httpClientBuilder.setDefaultRequestConfig(requestConfig).build();
-  }
-
-  protected HttpClient() {
   }
 
   public String getHttpContent(String url, List<Header> headers) {

--- a/src/main/java/io/jenkins/plugins/services/impl/HttpClient.java
+++ b/src/main/java/io/jenkins/plugins/services/impl/HttpClient.java
@@ -47,7 +47,11 @@ public class HttpClient {
   public String getHttpContent(String url, List<Header> headers) {
     final HttpGet get = new HttpGet(url);
     headers.stream().forEach(get::setHeader);
-
+    if (url.startsWith(this.configurationService.getGithubApiBase())) {
+      this.configurationService.getGithubCredentials().stream().forEach(get::setHeader);;
+    } else if (url.startsWith(this.configurationService.getJiraURL())) {
+      this.configurationService.getJiraCredentials().stream().forEach(get::setHeader);
+    }
 
     try (final CloseableHttpClient httpClient = getHttpClient(url);
          final CloseableHttpResponse response = httpClient.execute(get)) {

--- a/src/main/java/io/jenkins/plugins/services/impl/HttpClientJiraIssues.java
+++ b/src/main/java/io/jenkins/plugins/services/impl/HttpClientJiraIssues.java
@@ -8,14 +8,12 @@ import io.jenkins.plugins.services.ConfigurationService;
 import io.sentry.Sentry;
 import org.apache.http.Header;
 import org.apache.http.HttpStatus;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Inject;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.util.Collections;
@@ -23,6 +21,11 @@ import java.util.List;
 
 public class HttpClientJiraIssues extends HttpClient {
   private Logger logger = LoggerFactory.getLogger(HttpClientJiraIssues.class);
+
+  @Inject
+  public HttpClientJiraIssues(ConfigurationService configurationService) {
+    super(configurationService);
+  }
 
   @Override
   public String getHttpContent(String url, List<Header> headers) {

--- a/src/main/java/io/jenkins/plugins/services/impl/HttpClientReleases.java
+++ b/src/main/java/io/jenkins/plugins/services/impl/HttpClientReleases.java
@@ -22,6 +22,11 @@ public class HttpClientReleases extends HttpClient {
   private static final ObjectMapper objectMapper = new ObjectMapper();
   private Logger logger = LoggerFactory.getLogger(PluginEndpoint.class);
 
+  @Inject
+  public HttpClientReleases(ConfigurationService configurationService) {
+    super(configurationService);
+  }
+
   public PluginReleases getReleases(Plugin plugin) throws IOException {
     final String[] scmUrl = StringUtils.removeEnd(
       plugin.getScm().getLink().replaceAll("https://github.com/", "").replaceAll( "http://github.com/", ""),

--- a/src/main/java/io/jenkins/plugins/services/impl/HttpClientWikiService.java
+++ b/src/main/java/io/jenkins/plugins/services/impl/HttpClientWikiService.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
+import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -42,6 +43,11 @@ public class HttpClientWikiService extends HttpClient implements WikiService {
       WIKI_URLS.add(new ConfluenceDirectExtractor());
       WIKI_URLS.add(new GithubReadmeExtractor());
       WIKI_URLS.add(new GithubContentsExtractor());
+  }
+
+  @Inject
+  public HttpClientWikiService(ConfigurationService configurationService) {
+      super(configurationService);
   }
 
   @PostConstruct

--- a/src/test/java/io/jenkins/plugins/services/WikiServiceTest.java
+++ b/src/test/java/io/jenkins/plugins/services/WikiServiceTest.java
@@ -25,13 +25,7 @@ public class WikiServiceTest {
 
   @Before
   public void setUp() {
-    wikiService = new HttpClientWikiService() {
-      @Override
-      public void postConstruct() {
-        super.postConstruct();
-        this.configurationService = new DefaultConfigurationService();
-      }
-    };
+    wikiService = new HttpClientWikiService(new DefaultConfigurationService());
     wikiService.postConstruct();
   }
 

--- a/src/test/java/io/jenkins/plugins/services/impl/HttpClientJiraIssuesTest.java
+++ b/src/test/java/io/jenkins/plugins/services/impl/HttpClientJiraIssuesTest.java
@@ -22,8 +22,7 @@ public class HttpClientJiraIssuesTest {
   @Before
   public void setUp() {
 
-    this.httpClientJiraIssues = new HttpClientJiraIssues();
-    this.httpClientJiraIssues.configurationService = new DefaultConfigurationService() {
+    this.httpClientJiraIssues = new HttpClientJiraIssues(new DefaultConfigurationService() {
       @Override
       protected String getJiraUsername() {
         String username = super.getJiraUsername();
@@ -46,7 +45,7 @@ public class HttpClientJiraIssuesTest {
       public String getJiraURL() {
         return wireMockRule.baseUrl();
       }
-    };
+    });
   }
 
   @Test

--- a/src/test/java/io/jenkins/plugins/services/impl/HttpClientReleasesTest.java
+++ b/src/test/java/io/jenkins/plugins/services/impl/HttpClientReleasesTest.java
@@ -4,13 +4,18 @@ import io.jenkins.plugins.models.Plugin;
 import io.jenkins.plugins.models.PluginRelease;
 import io.jenkins.plugins.models.PluginReleases;
 import io.jenkins.plugins.models.Scm;
+import org.apache.http.Header;
+import org.apache.http.HttpHeaders;
+import org.apache.http.message.BasicHeader;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
@@ -47,23 +52,17 @@ public class HttpClientReleasesTest {
 
   @Before
   public void setUp() {
-    this.httpClientReleases = new HttpClientReleases();
-    this.httpClientReleases.configurationService = new DefaultConfigurationService() {
+    this.httpClientReleases = new HttpClientReleases(new DefaultConfigurationService() {
       @Override
-      public String getGithubClientId() {
-        return "";
-      }
-
-      @Override
-      public String getGithubClientSecret() {
-        return "";
+      public List<Header> getGithubCredentials() {
+        return Collections.singletonList(new BasicHeader(HttpHeaders.AUTHORIZATION, "Bearer faketoken"));
       }
 
       @Override
       public String getGithubApiBase() {
         return wireMockRule.baseUrl();
       }
-    };
+    });
   }
 
   @Test


### PR DESCRIPTION
Use a github app for accessing the github apis instead of client_id and client_secret in url which are being depreciated and don't work as basic auth.