### PR TITLE
make sure jira component names are lowercase

### DIFF
--- a/src/main/java/io/jenkins/plugins/services/impl/HttpClientJiraIssues.java
+++ b/src/main/java/io/jenkins/plugins/services/impl/HttpClientJiraIssues.java
@@ -46,7 +46,7 @@ public class HttpClientJiraIssues extends HttpClient {
   public JiraIssues getIssues(String pluginName, int startAt) throws IOException {
     int maxResults = 100;
     Sentry.getContext().addExtra("plugin-name", pluginName);
-    String component = pluginName.replaceAll("-plugin$", "") + "-plugin";
+    String component = this.getJiraComponentName(pluginName);
     JiraIssues jiraIssues = new JiraIssues();
 
     String query = URLEncoder.encode("project=JENKINS AND status in (Open, \"In Progress\", Reopened) AND component=" + component, "UTF-8");
@@ -105,5 +105,9 @@ public class HttpClientJiraIssues extends HttpClient {
     }
 
     return jiraIssues;
+  }
+
+  protected String getJiraComponentName(String pluginName) {
+    return pluginName.toLowerCase().replaceAll("-plugin$", "") + "-plugin";
   }
 }

--- a/src/test/java/io/jenkins/plugins/services/impl/HttpClientJiraIssuesTest.java
+++ b/src/test/java/io/jenkins/plugins/services/impl/HttpClientJiraIssuesTest.java
@@ -64,4 +64,10 @@ public class HttpClientJiraIssuesTest {
     assertEquals(0, issues.issues.size());
   }
 
+  @Test
+  public void testCapitalComponentName() throws IOException {
+    String componentName = this.httpClientJiraIssues.getJiraComponentName("MixedCasePlugin");
+
+    assertEquals("mixedcaseplugin-plugin", componentName);
+  }
 }


### PR DESCRIPTION
Makes it easier for a bunch of the legacy plugins with random case in their name.
