### PR TITLE
Reflect reverse dependencies in trend computation

### DIFF
--- a/src/main/java/io/jenkins/plugins/generate/GeneratePluginData.java
+++ b/src/main/java/io/jenkins/plugins/generate/GeneratePluginData.java
@@ -33,6 +33,8 @@ public class GeneratePluginData {
   private static final Logger logger = LoggerFactory.getLogger(GeneratePluginData.class);
 
   private static final String UPDATE_CENTER_JSON = "https://updates.jenkins.io/current/update-center.actual.json";
+  // trend value of plugin with no dependencies that was installed on 1% instances in a month
+  private static final double TREND_POINTS_PER_PERCENT = 1E4;
 
   public static void main(String[] args) {
     final GeneratePluginData generatePluginData = new GeneratePluginData();
@@ -82,9 +84,9 @@ public class GeneratePluginData {
       .map(p -> getInstallPct(p, 1))
       .max(Double::compare).orElse(0.0);
     double installPctLastMonth = getInstallPct(plugin, 1);
-    double installPctMonthBefore = getInstallPct(plugin, 2);
+    double installPctDiff =  installPctLastMonth - getInstallPct(plugin, 2);
     double independence = Math.max(0, 1 - dependentInstallPctLastMonth / installPctLastMonth);
-    int trend =  (int) ((installPctLastMonth - installPctMonthBefore) * independence * 1E4);
+    int trend =  (int) (installPctDiff * independence * TREND_POINTS_PER_PERCENT);
     plugin.getStats().setTrend(trend);
   }
 

--- a/src/main/java/io/jenkins/plugins/generate/parsers/StatsPluginDataParser.java
+++ b/src/main/java/io/jenkins/plugins/generate/parsers/StatsPluginDataParser.java
@@ -69,11 +69,6 @@ public class StatsPluginDataParser implements PluginDataParser {
           )
         ).sorted(Comparator.comparing(InstallationPercentageVersion::getVersion)).collect(Collectors.toList()));
         stats.setCurrentInstalls(!stats.getInstallations().isEmpty() ? stats.getInstallations().get(stats.getInstallations().size()-1).getTotal() : 0);
-        if (stats.getInstallations().size() > 1) {
-          final int size = stats.getInstallations().size();
-          final long trend = stats.getInstallations().get(size-1).getTotal() - stats.getInstallations().get(size-2).getTotal();
-          stats.setTrend(trend);
-        }
       } else {
         logger.warn(String.format("No statistics available for %s", name));
       }


### PR DESCRIPTION
Fixes https://github.com/jenkins-infra/plugin-site/issues/468

Two main changes:
* use install percentage instead of absolute numbers: otherwise when total number of recorded instances drops, plugins with many installs have a big negative trend, unused plugins would be more trending
* multiply by independence factor which depends on most popular reverse dependency

If plugin dependency graph was fixed, number of installs for any API plugin should be the max number of installs for its dependencies, so `1 - dependentInstallPctLastMonth / installPctLastMonth` should range from 0 to 1. If the dependency graph changes, the dependent plugin may have more installs than the API plugin, in that case we use 0 as independence factor.

This is less precise then breaking things up by version and checking dependencies of individual versions, but should be good enough.

Currently trending plugins according to the new algo:

```
localization-zh-cn:8577
role-strategy:4607
workflow-aggregator:3927
blueocean:3452
timestamper:3405
git-parameter:3310
publish-over-ssh:3259
ws-cleanup:3231
pipeline-github-lib:3129
email-ext:2924
```
EDIT: after removing optional dependencies
```
localization-zh-cn:8577
role-strategy:4607
workflow-aggregator:4148
nodejs:3655
blueocean:3452
timestamper:3405
git-parameter:3310
publish-over-ssh:3259
ws-cleanup:3231
pipeline-github-lib:3129
```
(the numbers roughly mean that e.g. Chinese localization was installed on 0.8577% more instances in April than in March)