### PR TITLE
Improve accuracy of linking GitHub usernames in release notes

### DIFF
--- a/src/main/java/io/jenkins/plugins/models/PluginRelease.java
+++ b/src/main/java/io/jenkins/plugins/models/PluginRelease.java
@@ -54,7 +54,7 @@ public class PluginRelease {
           this.body
             .replaceAll("<!--.*?-->", "")
             .replaceAll("#\\b([0-9]+)\\b", "[#$1](" + baseUrl + "/$1)")
-            .replaceAll("(\\b|\\s)+@(\\w+)(\\b|\\s)+", "$1[**@$2**](https://github.com/$2)$3")
+            .replaceAll("(\\b|\\s)+@([a-zA-Z\\d](?:[a-zA-Z\\d]|-(?=[a-zA-Z\\d])){0,38})(\\b|\\s)+", "$1[**@$2**](https://github.com/$2)$3")
         )
     );
     return htmlRenderer

--- a/src/test/java/io/jenkins/plugins/models/PluginReleaseTest.java
+++ b/src/test/java/io/jenkins/plugins/models/PluginReleaseTest.java
@@ -38,4 +38,19 @@ public class PluginReleaseTest {
       containsString("<h2>🐛 Bug Fixes</h2><ul><li>Handle windows paths (<a rel=\"nofollow\" href=\"https://github.com/jenkinsci/saml-plugin/issues/78\">#78</a>) <a rel=\"nofollow\" href=\"https://github.com/willwh\"><strong>@willwh</strong></a></li></ul><h2>📦 Dependency updates</h2><ul><li><a rel=\"nofollow\" href=\"https://issues.jenkins-ci.org/browse/JENKINS-60742\">JENKINS-60742</a> - Bump core to 2.176.1 version and bump plugin dependecies (<a rel=\"nofollow\" href=\"https://github.com/jenkinsci/saml-plugin/issues/82\">#82</a>) <a rel=\"nofollow\" href=\"https://github.com/kuisathaverat\"><strong>@kuisathaverat</strong></a></li><li><a rel=\"nofollow\" href=\"https://issues.jenkins-ci.org/browse/JENKINS-60679\">JENKINS-60679</a> - Bump bouncycastle api plugin due NoSuchMethodError exception (<a rel=\"nofollow\" href=\"https://github.com/jenkinsci/saml-plugin/issues/81\">#81</a>) <a rel=\"nofollow\" href=\"https://github.com/kuisathaverat\"><strong>@kuisathaverat</strong></a></li></ul><h2>📝 Documentation updates</h2><ul><li>Update TROUBLESHOOTING.md (<a rel=\"nofollow\" href=\"https://github.com/jenkinsci/saml-plugin/issues/80\">#80</a>) <a rel=\"nofollow\" href=\"https://github.com/duemir\"><strong>@duemir</strong></a></li><li>fix typo (<a rel=\"nofollow\" href=\"https://github.com/jenkinsci/saml-plugin/issues/79\">#79</a>) <a rel=\"nofollow\" href=\"https://github.com/tehmaspc\"><strong>@tehmaspc</strong></a></li></ul>")
     );
   }
+
+  @Test
+  public void rightLink2() {
+    PluginRelease pluginRelease = new PluginRelease(
+      "javadoc-1.6",
+      "1.6",
+      new Date(),
+      "https://github.com/jenkinsci/javadoc-plugin/releases/tag/javadoc-1.6",
+      "## \uD83D\uDE80 New features and improvements\r\n\r\n* Add `javadoc` symbol to the Javadoc step to simplify usage in Jenkins Pipeline (#12) @ybroeker\r\n\r\n## \uD83D\uDCDD Documentation updates\r\n\r\n* Move changelog to GitHub Releases (#14) @oleg-nenashev\r\n* Move docs from Wiki to GitHub (#13) @MarkEWaite\r\n\r\n## \uD83D\uDC7B Maintenance\r\n\r\n* Build the plugin with both JDK 1.8 and JDK 11 (#11) @batmat \r\n* Add Release Drafter (#14) @oleg-nenashev\r\n\r\n"
+    );
+    assertThat(
+      pluginRelease.getBodyHTML(),
+      containsString("<h2>🚀 New features and improvements</h2><ul><li>Add <code>javadoc</code> symbol to the Javadoc step to simplify usage in Jenkins Pipeline (<a rel=\"nofollow\" href=\"https://github.com/jenkinsci/javadoc-plugin/issues/12\">#12</a>) <a rel=\"nofollow\" href=\"https://github.com/ybroeker\"><strong>@ybroeker</strong></a></li></ul><h2>📝 Documentation updates</h2><ul><li>Move changelog to GitHub Releases (<a rel=\"nofollow\" href=\"https://github.com/jenkinsci/javadoc-plugin/issues/14\">#14</a>) <a rel=\"nofollow\" href=\"https://github.com/oleg-nenashev\"><strong>@oleg-nenashev</strong></a></li><li>Move docs from Wiki to GitHub (<a rel=\"nofollow\" href=\"https://github.com/jenkinsci/javadoc-plugin/issues/13\">#13</a>) <a rel=\"nofollow\" href=\"https://github.com/MarkEWaite\"><strong>@MarkEWaite</strong></a></li></ul><h2>👻 Maintenance</h2><ul><li>Build the plugin with both JDK 1.8 and JDK 11 (<a rel=\"nofollow\" href=\"https://github.com/jenkinsci/javadoc-plugin/issues/11\">#11</a>) <a rel=\"nofollow\" href=\"https://github.com/batmat\"><strong>@batmat</strong></a></li><li>Add Release Drafter (<a rel=\"nofollow\" href=\"https://github.com/jenkinsci/javadoc-plugin/issues/14\">#14</a>) <a rel=\"nofollow\" href=\"https://github.com/oleg-nenashev\"><strong>@oleg-nenashev</strong></a></li></ul>")
+    );
+  }
 }


### PR DESCRIPTION
The regular expression before only looked for usernames that contained
characters in the \w metacharacter class, which is alphanumerical as
well as underscores. However, this does not match GitHub's allowed
formats for usernames, which is alphanumerical plus hyphens, with the
limitation that it cannot start or end with hyphens, hyphens cannot be
doubled, and a maximum length of 39 characters. Rewrite the regular
expression to these standards to allow for all GitHub usernames to be
linked properly and add a new unit test to ensure it works. Regex
adapted from https://www.npmjs.com/package/github-username-regex.