### PR TITLE
Use fallback when default branch is not defined

### DIFF
--- a/src/main/java/io/jenkins/plugins/services/impl/GithubReadmeExtractor.java
+++ b/src/main/java/io/jenkins/plugins/services/impl/GithubReadmeExtractor.java
@@ -1,9 +1,10 @@
 package io.jenkins.plugins.services.impl;
 
+import io.jenkins.plugins.models.Plugin;
+import org.apache.commons.lang3.ObjectUtils;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import io.jenkins.plugins.models.Plugin;
 
 public class GithubReadmeExtractor extends GithubExtractor {
 
@@ -28,8 +29,8 @@ public class GithubReadmeExtractor extends GithubExtractor {
 
     @Override
     public String getBranch() {
-      String branch = matcher.group(3);
-      return branch == null ? plugin.getDefaultBranch() : branch;
+      return ObjectUtils.firstNonNull(matcher.group(3),
+        plugin.getDefaultBranch(), "master");
     }
 
     @Override


### PR DESCRIPTION
For some repositories we do have a correct documentation link but incorrect SCM link, so we don't get the defaultBranch from Update Center.

The branch is used in 2 places:  
* GH queries, there we could just remove it
* converting HTML links to absolute -- here we need a fallback

This uses `master` as fallback because that's the default for > 90% of plugins.