### PR TITLE
feat(docker) switch base image from unmaintained Alpine to slim (Debian)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jetty:9-alpine
+FROM jetty:9-jdk8-slim
 COPY target/*.war $JETTY_BASE/webapps/ROOT.war
 RUN java -jar $JETTY_HOME/start.jar \
   --create-startd \


### PR DESCRIPTION
- The Alpine version of Jetty is not updated since 2 years and absent from their tag list (ref. https://hub.docker.com/_/jetty)
- It's using Alpine 3.9 which is known for its DNS issues when using `ndots:5` on resolv.conf. We need at least `Alpine 3.11` (ref. https://github.com/gliderlabs/docker-alpine/issues/476#issuecomment-574601546 for instance) to work p^roperly with Kubernetes DNS