### PR TITLE
Use https:// rather than git:// to clone repo

### DIFF
--- a/src/main/java/io/jenkins/plugins/generate/parsers/StatsPluginDataParser.java
+++ b/src/main/java/io/jenkins/plugins/generate/parsers/StatsPluginDataParser.java
@@ -23,7 +23,7 @@ public class StatsPluginDataParser implements PluginDataParser {
     try {
       statisticsPath = Files.createTempDirectory("infra-statistics");
       logger.info("Cloning jenkins-infra/infra-statistics");
-      Git.cloneRepository().setURI("git://github.com/jenkins-infra/infra-statistics.git").setBranch("gh-pages").setDirectory(statisticsPath.toFile()).call();
+      Git.cloneRepository().setURI("https://github.com/jenkins-infra/infra-statistics.git").setBranch("gh-pages").setDirectory(statisticsPath.toFile()).call();
       logger.info("Finished cloning jenkins-infra/infra-statistics");
     } catch (Exception e) {
       logger.error("Problem downloading plugin statistics", e);


### PR DESCRIPTION
## Use https:// rather than git:// protocol to clone

GitHub is deprecating git protocol access

https://github.blog/2021-09-01-improving-git-protocol-security-github/#when-are-these-changes-effective

Should fix the failing job at https://ci.jenkins.io/job/Infra/job/plugin-site-api/job/generate-data/
