### PR TITLE
chore: switch from `infra.runMaven` to `infra.runWithMaven`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,11 +48,10 @@ node('docker&&linux') {
                         'DATA_FILE_URL=http://nginx/plugins.json.gzip',
                     ]) {
                         List<String> mvnOptions = ['-Dmaven.test.failure.ignore','verify']
-                        infra.runMaven(
+                        infra.runWithMaven(
                             mvnOptions,
                             /*jdk*/ "8",
                             /*extraEnv*/ null,
-                            /*settingsFile*/ null,
                             /*addToolEnv*/ false
                           )
                     }


### PR DESCRIPTION
Switching shared pipeline functions in order to simplify `infra.runMaven` parameters (cf https://github.com/jenkins-infra/pipeline-library/pull/592)