### PR TITLE
Revert "chore: switch from `infra.runMaven` to `infra.runWithMaven`"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,10 +48,11 @@ node('docker&&linux') {
                         'DATA_FILE_URL=http://nginx/plugins.json.gzip',
                     ]) {
                         List<String> mvnOptions = ['-Dmaven.test.failure.ignore','verify']
-                        infra.runWithMaven(
+                        infra.runMaven(
                             mvnOptions,
                             /*jdk*/ "8",
                             /*extraEnv*/ null,
+                            /*settingsFile*/ null,
                             /*addToolEnv*/ false
                           )
                     }


### PR DESCRIPTION
Reverts jenkins-infra/plugin-site-api#112

Reverting as I don't understand why `java.lang.NoSuchMethodError: No such DSL method 'runWithMaven' found` 🤔 🙁 