### PR TITLE
chore: switch from `infra.runMaven` to `infra.runWithMaven`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,12 +47,10 @@ node('docker&&linux') {
                     withEnv([
                         'DATA_FILE_URL=http://nginx/plugins.json.gzip',
                     ]) {
-                        List<String> mvnOptions = ['-Dmaven.test.failure.ignore','verify']
-                        infra.runMaven(
-                            mvnOptions,
+                        infra.runWithMaven(
+                            'mvn -Dmaven.test.failure.ignore verify',
                             /*jdk*/ "8",
                             /*extraEnv*/ null,
-                            /*settingsFile*/ null,
                             /*addToolEnv*/ false
                           )
                     }


### PR DESCRIPTION
Fixup of https://github.com/jenkins-infra/plugin-site-api/pull/112 (`infra.runWithMaven` expects a string as first argument, not a list of strings 😅)

Switching shared pipeline functions in order to simplify `infra.runMaven` parameters (cf https://github.com/jenkins-infra/pipeline-library/pull/592)

