### PR TITLE
Update gitter URL

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = Plugin Site API
 
-image:https://badges.gitter.im/jenkinsci/docs.svg[link="https://gitter.im/jenkinsci/docs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"]
+image:https://badges.gitter.im/jenkinsci/docs.svg[link="https://app.gitter.im/#/room/#jenkins/docs:matrix.org"]
 image:https://img.shields.io/github/release/jenkins-infra/plugin-site-api.svg?label=release[link="https://github.com/jenkins-infra/plugin-site-api/releases/latest"]
 image:https://img.shields.io/docker/pulls/jenkinsciinfra/plugin-site-api?label=jenkinsciinfra%2Fplugin-site-api&logo=docker&logoColor=white[link="https://hub.docker.com/r/jenkinsciinfra/plugin-site-api"]
 


### PR DESCRIPTION
Since yesterday, February the 13th, Gitter migrated to matrix. Existing links are redirected, but some redirections broke or use a different URL.
This PR updates the link to use the final destination, to ensure we don't rely on possible breaking redirections.