### PR TITLE
feat: Switch JDK version of the parent image to latest Temurin JDK8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jetty:9-jdk8-slim
+FROM jetty:9-jdk8-eclipse-temurin
 COPY target/*.war $JETTY_BASE/webapps/ROOT.war
 RUN java -jar $JETTY_HOME/start.jar \
   --create-startd \


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3774 need to update the jdk to a compatible with `cgroup v2`