### PR TITLE
chore(Jenkinsfile) fix failing build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ node('docker&&linux') {
         stage('Generate Plugin Data') {
           infra.runWithMaven(
             'mvn -PgeneratePluginData',
-            /*jdk*/ '17',
+            /*jdk*/ '11',
             /*extraEnv*/ null,
             /*addToolEnv*/ false
           )
@@ -51,7 +51,7 @@ node('docker&&linux') {
               ]) {
                 infra.runWithMaven(
                     'mvn -Dmaven.test.failure.ignore verify',
-                    /*jdk*/ '17',
+                    /*jdk*/ '11',
                     /*extraEnv*/ null,
                     /*addToolEnv*/ false
                   )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,11 +79,8 @@ node('docker&&linux') {
              * calls against it before calling it successful
              */
             stage('Verify Container') {
-                container.withRun("--link ${c.id}:nginx -e DATA_FILE_URL=http://nginx/plugins.json.gzip") { api ->
-                    docker.image('bash@sha256:95599adce80c5f938a8445eca59a8ac4e380f75b0e3e21971b37099c0c54a187').inside("--link ${api.id}:api") {
-                        sh 'ls /usr/bin'
-                        sh '/usr/bin/wget --debug -O /dev/null --retry-connrefused --timeout 120 --tries=15 http://api:8080/versions'
-                    }
+                container.withRun("--link ${c.id}:nginx -p 8080:8080 -e DATA_FILE_URL=http://nginx/plugins.json.gzip") { api ->
+                    sh 'wget --debug -O /dev/null --retry-connrefused --timeout 120 --tries=15 http://localhost:8080/versions'
                 }
             }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,12 +49,7 @@ node('docker&&linux') {
               withEnv([
                 'DATA_FILE_URL=http://localhost/plugins.json.gzip',
               ]) {
-                infra.runWithMaven(
-                    'mvn --no-transfer-progress -Dmaven.test.failure.ignore verify --version',
-                    /*jdk*/ '8',
-                    /*extraEnv*/ null,
-                    /*addToolEnv*/ false
-                  )
+                infra.runMaven(['-Dmaven.test.failure.ignore',  'verify'])
               }
 
                 /** archive all our artifacts for reporting later */

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ node('docker&&linux') {
         stage('Generate Plugin Data') {
           infra.runWithMaven(
             'mvn --no-transfer-progress -PgeneratePluginData',
-            /*jdk*/ '11',
+            /*jdk*/ '17',
             /*extraEnv*/ null,
             /*addToolEnv*/ false
           )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ node('docker&&linux') {
                 'DATA_FILE_URL=http://localhost/plugins.json.gzip',
               ]) {
                 infra.runWithMaven(
-                    'mvn --no-transfer-progress -Dmaven.test.failure.ignore verify',
+                    'mvn --no-transfer-progress -Dmaven.test.failure.ignore verify --version',
                     /*jdk*/ '8',
                     /*extraEnv*/ null,
                     /*addToolEnv*/ false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,7 @@ node('docker&&linux') {
               ]) {
                 infra.runWithMaven(
                     'mvn --no-transfer-progress -Dmaven.test.failure.ignore verify',
-                    /*jdk*/ '11',
+                    /*jdk*/ '8',
                     /*extraEnv*/ null,
                     /*addToolEnv*/ false
                   )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,12 +26,7 @@ node('docker&&linux') {
 
     timestamps {
         stage('Generate Plugin Data') {
-          infra.runWithMaven(
-            'mvn --no-transfer-progress -PgeneratePluginData',
-            /*jdk*/ '17',
-            /*extraEnv*/ null,
-            /*addToolEnv*/ false
-          )
+          infra.runMaven(['-PgeneratePluginData'], '17')
         }
 
         /*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ node('docker&&linux') {
         stage('Generate Plugin Data') {
           infra.runWithMaven(
             'mvn --no-transfer-progress -PgeneratePluginData',
-            /*jdk*/ '17',
+            /*jdk*/ '11',
             /*extraEnv*/ null,
             /*addToolEnv*/ false
           )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ node('docker&&linux') {
     timestamps {
         stage('Generate Plugin Data') {
           infra.runWithMaven(
-            'mvn -PgeneratePluginData',
+            'mvn --no-transfer-progress -PgeneratePluginData',
             /*jdk*/ '11',
             /*extraEnv*/ null,
             /*addToolEnv*/ false
@@ -50,7 +50,7 @@ node('docker&&linux') {
                 'DATA_FILE_URL=http://localhost/plugins.json.gzip',
               ]) {
                 infra.runWithMaven(
-                    'mvn -Dmaven.test.failure.ignore verify',
+                    'mvn --no-transfer-progress -Dmaven.test.failure.ignore verify',
                     /*jdk*/ '11',
                     /*extraEnv*/ null,
                     /*addToolEnv*/ false


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3778

Blocks #119 and #122

(edited)

The following fixes are introduced to correct the build:

- Stop generating data and building from inside `maven` containers image while we have fully fledged maven and JDK tools
- Use the jenkins-infra/pipeline-library shared library object `infra` to execute Maven with its `runMaven()` function to benefit from our tools installations and the Artifact caching proxying.
- Uses JDK17 for generating data but ensure JDK8 is used for the build & test
- Stop using a custom container in the pipeline to run `wget` and use the Jenkins Infra image template's `wget` instead


💡 Please note that the Nginx container (serving the frontend static data) and API container (used for a sanity check of the freshly built image) are now using fixed published ports: `80` for the frontend and `8080` . Since the agent are ephemeral VMs (to ensure safe Docker usage), there is no problem reserving these ports through Docker.