### PR TITLE
chore(Jenkinsfile) do not enable ACP on trusted.ci

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ node('docker&&linux') {
 
     timestamps {
         stage('Generate Plugin Data') {
-          infra.runMaven(['-PgeneratePluginData'], '17')
+          infra.runMaven(['-PgeneratePluginData'], '17', null, true, !infra.isTrusted())
         }
 
         /*
@@ -44,7 +44,7 @@ node('docker&&linux') {
               withEnv([
                 'DATA_FILE_URL=http://localhost/plugins.json.gzip',
               ]) {
-                infra.runMaven(['-Dmaven.test.failure.ignore',  'verify'])
+                infra.runMaven(['-Dmaven.test.failure.ignore',  'verify'], '8', null, true, !infra.isTrusted())
               }
 
                 /** archive all our artifacts for reporting later */


### PR DESCRIPTION
Fixup of #120 : the artifact caching proxy is not available on trusted.ci.jenkins.io.

This PR fixes the build so it will pass on trusted.ci.jenkins.io.

Blocks #121 and #119