### PR TITLE
chore(docker): Update jetty base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jetty:9-jdk8-eclipse-temurin
+FROM jetty:12.0.1-jdk17-eclipse-temurin
 COPY target/*.war $JETTY_BASE/webapps/ROOT.war
 RUN java -jar $JETTY_HOME/start.jar \
   --create-startd \

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM jetty:9-alpine
+FROM jetty:12.0.1-jdk17-eclipse-temurin
 
 USER root
 


### PR DESCRIPTION
I don't know if this is necessary, but I don't like keeping an image based on the aging (but trustworthy) JDK8. 🤷 

I tested it locally, and it worked the same way as the previous image.