### PR TITLE
chore: build on `infra.ci.jenkins.io` and use `buildDockerAndPublishImage`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM jetty:9-jdk8-eclipse-temurin
 COPY target/*.war $JETTY_BASE/webapps/ROOT.war
-RUN java -jar $JETTY_HOME/start.jar \
+RUN java -jar "${JETTY_HOME}/start.jar" \
   --create-startd \
   --approve-all-licenses \
   --add-to-start=logging-logback \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 #!/usr/bin/env groovy
 
 def isPullRequest = !!(env.CHANGE_ID)
-def pushToDocker = infra.isTrusted()
 String shortCommit = ''
 String tag = ''
 String dockerImage = ''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-@Library('pipeline-library@pull/<pull-request-number>/head') _
+@Library('pipeline-library@pull/784/head') _
 
 def isPullRequest = !!(env.CHANGE_ID)
 String shortCommit = ''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,6 @@ node('linux || linux-amd64-docker') {
                         'DATA_FILE_URL=http://localhost/plugins.json.gzip',
                     ]) {
                         infra.runMaven(['-Dmaven.test.failure.ignore',  'verify'], '8', null, true, !infra.isTrusted())
-                        stash name: 'build', includes: 'plugins.json.gzip,target/**/*'
                     }
 
                     /** archive all our artifacts for reporting later */
@@ -82,7 +81,7 @@ node('linux || linux-amd64-docker') {
         } else {
             stage('Maven build') {
                 infra.runMaven(['-Dmaven.test.skip=true',  'package'], '8')
-                stash name: 'build', includes: 'plugins.json.gzip,target/**/*'
+                stash name: 'build', includes: 'target/*.war'
             }
             stage('Build and publish Docker image') {
                 buildDockerAndPublishImage('plugin-site-api', [unstash: 'build', targetplatforms: 'linux/amd64'])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,5 @@
 #!/usr/bin/env groovy
+
 def isPullRequest = !!(env.CHANGE_ID)
 String shortCommit = ''
 String tag = ''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,5 @@
 #!/usr/bin/env groovy
+@Library('pipeline-library@pull/<pull-request-number>/head') _
 
 def isPullRequest = !!(env.CHANGE_ID)
 String shortCommit = ''
@@ -85,7 +86,7 @@ node('linux || linux-amd64-docker') {
             stash name: 'build', includes: 'plugins.json.gzip,target/**/*'
         }
         stage('Build and publish Docker image') {
-            buildDockerAndPublishImage('plugin-site-api', [unstash: 'build', targetplatforms: 'linux/amd64'])
+            buildDockerAndPublishImage('plugin-site-api', [unstash: 'build', enablePublication: infra.isInfra(), targetplatforms: 'linux/amd64'])
         }
         stage('Archive Artifacts') {
             archiveArtifacts artifacts: 'target/*.war, target/*.json.gzip', fingerprint: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,11 +60,11 @@ node('linux || linux-amd64-docker') {
             def container
             stage('Containerize') {
                 if (tag.isEmpty()) {
-                echo "No tag for this commit, creating a docker image with ${shortCommit} version..."
-                dockerImage = "jenkinsciinfra/plugin-site-api:${env.BUILD_ID}-${shortCommit}"
+                    echo "No tag for this commit, creating a docker image with ${shortCommit} version..."
+                    dockerImage = "jenkinsciinfra/plugin-site-api:${env.BUILD_ID}-${shortCommit}"
                 } else {
-                echo "Tag found for this commit, creating a docker image with ${tag} version..."
-                dockerImage = "jenkinsciinfra/plugin-site-api:${tag}"
+                    echo "Tag found for this commit, creating a docker image with ${tag} version..."
+                    dockerImage = "jenkinsciinfra/plugin-site-api:${tag}"
                 }
                 container = docker.build(dockerImage, '--no-cache --rm .')
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,6 +87,7 @@ node('linux || linux-amd64-docker') {
                 buildDockerAndPublishImage('plugin-site-api', [unstash: 'build', targetplatforms: 'linux/amd64'])
             }
         }
+
         stage('Archive Artifacts') {
             archiveArtifacts artifacts: 'target/*.war, target/*.json.gzip', fingerprint: true
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,6 +46,7 @@ node('linux || linux-amd64-docker') {
                         'DATA_FILE_URL=http://localhost/plugins.json.gzip',
                     ]) {
                         infra.runMaven(['-Dmaven.test.failure.ignore',  'verify'], '8', null, true, !infra.isTrusted())
+                        stash name: 'build', includes: 'plugins.json.gzip,target/**/*'
                     }
 
                     /** archive all our artifacts for reporting later */


### PR DESCRIPTION
This PR uses `buildDockerAndPublishImage` from the shared pipeline library to build and publish the Docker image, on infra.ci.jenkins.io only for now until https://github.com/jenkins-infra/pipeline-library/pull/784 is ready.

This will allow the publication of an arm64 image later.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3619#issuecomment-1805437441