### PR TITLE
chore(Jenkinsfile): explicitly disable autoSemVer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,7 +84,7 @@ node('linux-arm64') {
                 stash name: 'build', includes: 'target/*.war'
             }
             stage('Build and publish Docker image') {
-                buildDockerAndPublishImage('plugin-site-api', [unstash: 'build', targetplatforms: 'linux/amd64,linux/arm64'])
+                buildDockerAndPublishImage('plugin-site-api', [unstash: 'build', targetplatforms: 'linux/amd64,linux/arm64', automaticSemanticVersioning: false])
             }
         }
 


### PR DESCRIPTION
Related to - https://github.com/jenkins-infra/helpdesk/issues/4165

https://github.com/jenkins-infra/pipeline-library/pull/929 sets `automaticSemanticVersioning` true by default.

Since we want to avoid  automatic versioning, this PR explicitly disables automatic semantic versioning while building the docker image.

This will be a non-regression test for the pipeline.


