### PR TITLE
feat: add a pipeline to publish plugin data to reports.jenkins.io from infra.ci.jenkins.io

### DIFF
--- a/Jenkinsfile_publish
+++ b/Jenkinsfile_publish
@@ -1,0 +1,69 @@
+#!/usr/bin/env groovy
+
+pipeline {
+    agent {
+        label 'linux-arm64'
+    }
+
+    options {
+        disableConcurrentBuilds()
+        buildDiscarder(logRotator(numToKeepStr: '7'))
+        timestamps()
+        timeout(time: 1, unit: 'HOURS')
+    }
+    triggers {
+        cron('H/10 * * * *')
+    }
+
+    stages {
+        stage('Checkout') {
+            steps {
+                checkout scm
+            }
+        }
+
+        stage('Generate') {
+            environment {
+                PLUGIN_DOCUMENTATION_URL = 'https://updates.jenkins.io/current/plugin-documentation-urls.json'
+            }
+            steps {
+                script {
+                    infra.runMaven(['-PgeneratePluginData'], '8')
+                }
+            }
+
+            post {
+                success {
+                    dir('target') {
+                        archiveArtifacts artifacts: 'plugins.json.gzip', fingerprint: true
+                    }
+                }
+            }
+        }
+        stage('Publish') {
+            when {
+                expression {
+                    allOf {
+                        env.BRANCH_IS_PRIMARY
+                        infra.isInfra()
+                    }
+                }
+            }
+            steps {
+                sh '''
+                mkdir -p plugin-site-api
+                cp target/plugins.json.gzip plugin-site-api
+                '''
+                publishReports(['plugin-site-api/plugins.json.gzip'])
+            }
+
+            post {
+                success {
+                    dir('target') {
+                        archiveArtifacts artifacts: 'plugins.json.gzip', fingerprint: true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/README.adoc
+++ b/README.adoc
@@ -48,7 +48,7 @@ contains new data. If so the application will the reindex the Elasticsearch data
 [source,bash]
 ----
 GITHUB_TOKEN=token from https://github.com/settings/tokens
-DATA_FILE_URL="https://ci.jenkins.io/job/Infra/job/plugin-site-api/job/generate-data/lastSuccessfulBuild/artifact/plugins.json.gzip" mvn jetty:run
+DATA_FILE_URL="https://reports.jenkins.io/plugin-site-api/plugins.json.gzip" mvn jetty:run
 ----
 
 This will launch an embedded Jetty container accessible at `http://localhost:8080`.


### PR DESCRIPTION
This change adds a dedicated pipeline to publish plugins.json.gzip to https://reports.jenkins.io/plugin-site-api from infra.ci.jenkins.io only.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4976

#### Testing done

Replay on a temporary job: https://infra.ci.jenkins.io/job/reports/job/plugin-site-api-test/job/master/8/
- Build logs: [#8.txt](https://github.com/user-attachments/files/25096773/8.txt)
- Result: https://reports.jenkins.io/plugin-site-api, https://reports.jenkins.io/plugin-site-api/plugins.json.gzip
