### PR TITLE
chore: use JDK25 to publish data

### DIFF
--- a/Jenkinsfile_publish
+++ b/Jenkinsfile_publish
@@ -28,7 +28,7 @@ pipeline {
             }
             steps {
                 script {
-                    infra.runMaven(['-PgeneratePluginData'], '17')
+                    infra.runMaven(['-PgeneratePluginData'], '25')
                 }
             }
 

--- a/Jenkinsfile_publish
+++ b/Jenkinsfile_publish
@@ -28,7 +28,7 @@ pipeline {
             }
             steps {
                 script {
-                    infra.runMaven(['-PgeneratePluginData'], '8')
+                    infra.runMaven(['-PgeneratePluginData'], '17')
                 }
             }
 


### PR DESCRIPTION
This change uses a more recent JDK version in the publish pipeline like in the main one: https://github.com/jenkins-infra/plugin-site-api/blob/79564bcfebd4840cc3cdf050f496528ec938b017/Jenkinsfile#L28

Refs:
- https://github.com/jenkins-infra/plugin-site-api/issues/164
- https://github.com/jenkins-infra/helpdesk/issues/5081#issuecomment-4429857307

#### Testing done

Replay: https://infra.ci.jenkins.io/job/reports/job/plugin-site-api/job/master/13591/

Artifact created, same size as the previous one